### PR TITLE
[WIP] Introduce the API through django ninja

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,5 @@
 [MASTER]
 ignore=migrations
+
+[MESSAGES CONTROL]
+disable=R0801

--- a/backends/api_v1.py
+++ b/backends/api_v1.py
@@ -7,9 +7,9 @@ from ninja import NinjaAPI
 from .schemas import BackendSchemaOut
 from .models import Backend
 
-api = NinjaAPI()
+api = NinjaAPI(version="1.0.0")
 
-@api.get("{backend_name}/get_config", response = BackendSchemaOut)
+@api.get("{backend_name}/get_config", response = BackendSchemaOut, tags=["Backend"])
 def get_config(request, backend_name:str):
     """
     Returns the list of backends.
@@ -52,7 +52,7 @@ def get_config(request, backend_name:str):
     return config_dict
 
 
-@api.get("/backends", response=List[BackendSchemaOut])
+@api.get("/backends", response=List[BackendSchemaOut], tags=["Backend"])
 def list_backends(request):
     """
     Returns the list of backends.

--- a/backends/api_v1.py
+++ b/backends/api_v1.py
@@ -9,8 +9,9 @@ from .models import Backend
 
 api = NinjaAPI(version="1.0.0")
 
-@api.get("{backend_name}/get_config", response = BackendSchemaOut, tags=["Backend"])
-def get_config(request, backend_name:str):
+
+@api.get("{backend_name}/get_config", response=BackendSchemaOut, tags=["Backend"])
+def get_config(request, backend_name: str):
     """
     Returns the list of backends.
     """
@@ -46,9 +47,7 @@ def get_config(request, backend_name:str):
         config_dict["basis_gates"].append(gate["name"])
 
     # it would be really good to remove the first part and replace it by the domain
-    config_dict["url"] = (
-        "https://coquma-sim.herokuapp.com/api/" + backend.name + "/"
-    )
+    config_dict["url"] = "https://coquma-sim.herokuapp.com/api/" + backend.name + "/"
     return config_dict
 
 

--- a/backends/api_v1.py
+++ b/backends/api_v1.py
@@ -1,0 +1,99 @@
+"""
+Module that defines the user api v1 which goes through django-ninja.
+"""
+from typing import List
+from ninja import NinjaAPI
+
+from .schemas import BackendSchemaOut
+from .models import Backend
+
+api = NinjaAPI()
+
+@api.get("{backend_name}/get_config", response = BackendSchemaOut)
+def get_config(request, backend_name:str):
+    """
+    Returns the list of backends.
+    """
+    # pylint: disable=W0613, E1101
+    backend = Backend.objects.get(name=backend_name)
+    config_dict = {
+        "conditional": False,
+        "coupling_map": "linear",
+        "dynamic_reprate_enabled": False,
+        "local": False,
+        "memory": True,
+        "open_pulse": False,
+    }
+    config_dict["display_name"] = backend.name
+    config_dict["description"] = backend.description
+    config_dict["backend_version"] = backend.version
+    config_dict["cold_atom_type"] = backend.cold_atom_type
+    config_dict["simulator"] = backend.simulator
+    config_dict["num_species"] = backend.num_species
+    config_dict["max_shots"] = backend.max_shots
+    config_dict["max_experiments"] = backend.max_experiments
+    config_dict["n_qubits"] = backend.num_wires
+    config_dict["supported_instructions"] = backend.supported_instructions
+    config_dict["wire_order"] = backend.wire_order
+    if backend.simulator:
+        config_dict["backend_name"] = "synqs_" + backend.name + "_simulator"
+    else:
+        config_dict["backend_name"] = "synqs_" + backend.name + "_machine"
+    config_dict["gates"] = backend.gates
+
+    config_dict["basis_gates"] = []
+    for gate in config_dict["gates"]:
+        config_dict["basis_gates"].append(gate["name"])
+
+    # it would be really good to remove the first part and replace it by the domain
+    config_dict["url"] = (
+        "https://coquma-sim.herokuapp.com/api/" + backend.name + "/"
+    )
+    return config_dict
+
+
+@api.get("/backends", response=List[BackendSchemaOut])
+def list_backends(request):
+    """
+    Returns the list of backends.
+    """
+    # pylint: disable=W0613, E1101
+    backends = Backend.objects.all()
+    backend_list = []
+    for backend in backends:
+        config_dict = {
+            "conditional": False,
+            "coupling_map": "linear",
+            "dynamic_reprate_enabled": False,
+            "local": False,
+            "memory": True,
+            "open_pulse": False,
+        }
+        config_dict["display_name"] = backend.name
+        config_dict["description"] = backend.description
+        config_dict["backend_version"] = backend.version
+        config_dict["cold_atom_type"] = backend.cold_atom_type
+        config_dict["simulator"] = backend.simulator
+        config_dict["num_species"] = backend.num_species
+        config_dict["max_shots"] = backend.max_shots
+        config_dict["max_experiments"] = backend.max_experiments
+        config_dict["n_qubits"] = backend.num_wires
+        config_dict["supported_instructions"] = backend.supported_instructions
+        config_dict["wire_order"] = backend.wire_order
+        if backend.simulator:
+            config_dict["backend_name"] = "synqs_" + backend.name + "_simulator"
+        else:
+            config_dict["backend_name"] = "synqs_" + backend.name + "_machine"
+        config_dict["gates"] = backend.gates
+
+        config_dict["basis_gates"] = []
+        for gate in config_dict["gates"]:
+            config_dict["basis_gates"].append(gate["name"])
+
+        # it would be really good to remove the first part and replace it by the domain
+        config_dict["url"] = (
+            "https://coquma-sim.herokuapp.com/api/" + backend.name + "/"
+        )
+
+        backend_list.append(config_dict)
+    return backend_list

--- a/backends/schemas.py
+++ b/backends/schemas.py
@@ -1,0 +1,42 @@
+"""
+The schemas that define our communication with the api_v1.
+"""
+
+
+from typing import List
+from ninja import ModelSchema
+from .models import Backend
+
+# pylint: disable=R0903
+class BackendSchemaOut(ModelSchema):
+    """
+    The schema send out to detail the configuration of the backend. We follow the
+    conventions of the qiskit configuration dictionary here
+    """
+
+    display_name: str
+    conditional: bool = False
+    coupling_map: str = "linear"
+    dynamic_reprate_enabled: bool = False
+    local: bool = False
+    memory: bool = True
+    open_pulse: bool = False
+    backend_version: str
+    n_qubits: int
+    backend_name: str
+    basis_gates: List[str]
+    url: str
+    # pylint: disable=C0115
+    class Config:
+        model = Backend
+        model_fields = [
+            "description",
+            "cold_atom_type",
+            "max_experiments",
+            "max_shots",
+            "simulator",
+            "wire_order",
+            "num_species",
+            "gates",
+            "supported_instructions",
+        ]

--- a/backends/urls.py
+++ b/backends/urls.py
@@ -6,6 +6,8 @@ html addresses.
 from django.urls import path
 from backends import views
 
+from .api_v1 import api
+
 urlpatterns = [
     path("<str:backend_name>/get_config/", views.get_config, name="get_config"),
     path("<str:backend_name>/post_job/", views.post_job, name="post_job"),
@@ -27,4 +29,5 @@ urlpatterns = [
     path(
         "<str:backend_name>/get_user_jobs/", views.get_user_jobs, name="get_user_jobs"
     ),
+    path("v1/", api.urls),
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ colorama==0.4.4
 dj-database-url==0.5.0
 Django==3.2.11
 django-on-heroku==1.1.2
+django-ninja==0.16.1
 dropbox==10.10.0
 ghp-import==2.0.2
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ click==7.1.2
 dj-database-url==0.5.0
 Django==3.2.11
 django-on-heroku==1.1.2
+django-ninja==0.16.1
 dropbox==10.10.0
 gunicorn==20.1.0
 jsonschema==3.2.0


### PR DESCRIPTION
We will start to transition the API to `django-ninja`. Here we do the first step for the information concerning the back-end.

We further introduce an API end-point that let's the spooler test that the config of `qlue` is as the spooler wishes. 